### PR TITLE
Fix final PnL/volume on full close

### DIFF
--- a/alexbot.py
+++ b/alexbot.py
@@ -880,7 +880,11 @@ class AlexBot:
 
                 if new_amt <= 1e-8:
 
-                    closed_amt = self.base_sizes.get((sym, side), old_amt)
+                    # Use the amount from the database, which reflects the
+                    # actual position size right before this fill. Internal
+                    # trackers might drift after partial fills, so relying on
+                    # ``old_amt`` ensures correct final volume.
+                    closed_amt = old_amt
                     rr_val = self._calc_rr(side, closed_amt, new_rpnl, old_entry, stop_p, take_p)
                     display_vol = closed_amt * self.fake_coef if self.use_fake_report else closed_amt
                     display_pnl = new_rpnl * self.fake_coef if self.use_fake_report else new_rpnl


### PR DESCRIPTION
## Summary
- account for the position size from the database when closing the last piece of a trade so PnL/volume are correct

## Testing
- `python -m py_compile alexbot.py`

------
https://chatgpt.com/codex/tasks/task_e_688c8fef3a408322942e403934a9829c